### PR TITLE
Add cross-platform defaults for DalamudLibPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ This is not designed to be the simplest possible example, but it is also not des
 The intention is less that any of this is used directly in other projects, and more to show how similar things can be done.
 
 ## To Use
+
+### Prerequisites
+
+SamplePlugin assumes all the following prerequisites are met:
+
+* XIVLauncher, FINAL FANTASY XIV, and Dalamud have all been installed and the game has been run with Dalamud at least once.
+* XIVLauncher is installed to its default directories and configurations.
+  * If a custom path is required for Dalamud's dev directory, it must be set with the `DALAMUD_HOME` environment variable.
+* A .NET Core 7 SDK has been installed and configured, or is otherwise available. (In most cases, the IDE will take care of this.)
+
 ### Building
 
 1. Open up `SamplePlugin.sln` in your C# editor of choice (likely [Visual Studio 2022](https://visualstudio.microsoft.com) or [JetBrains Rider](https://www.jetbrains.com/rider/)).

--- a/SamplePlugin/SamplePlugin.csproj
+++ b/SamplePlugin/SamplePlugin.csproj
@@ -18,6 +18,7 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,12 +29,10 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-  
-   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
-    <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+    <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+    <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
+    <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
+    <DalamudLibPath Condition="$(DALAMUD_HOME) != ''">$(DALAMUD_HOME)/</DalamudLibPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request aims to change how `DalamudLibPath` is loaded in by default, now attempting to select the default path by operating system:

* Windows: `%APPDATA%\XIVLauncher\addon\Hooks\dev\`
* Linux: `~/.xlcore/dalamud/Hooks/dev/`
* macOS: `~/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/`

If the `DALAMUD_HOME` environment variable is set, it will take precedence over the autodiscovered value.