### PR TITLE
Remove InternalName from manifest

### DIFF
--- a/SamplePlugin/SamplePlugin.json
+++ b/SamplePlugin/SamplePlugin.json
@@ -3,7 +3,6 @@
   "Name": "Sample Plugin",
   "Punchline": "A short one-liner that shows up in /xlplugins.",
   "Description": "A description that shows up in /xlplugins. List any major slash-command(s).",
-  "InternalName": "samplePlugin",
   "ApplicableVersion": "any",
   "Tags": [
     "sample",


### PR DESCRIPTION
The manifest field `InternalName` is [automatically set](https://github.com/goatcorp/DalamudPackager/blob/084f66e/DalamudPackager/DalamudPackager.cs#L432) to the assembly name by DalamudPackager.
It can be dropped from the example, so it doesn't confuse new plugin devs. 🌱