### PR TITLE
Cleanup and add more examples

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -113,7 +113,7 @@ resharper_use_indent_from_vs = false
 # ReSharper inspection severities
 resharper_arrange_missing_parentheses_highlighting = hint
 resharper_arrange_redundant_parentheses_highlighting = hint
-resharper_arrange_this_qualifier_highlighting = none
+resharper_arrange_this_qualifier_highlighting = hint
 resharper_arrange_type_member_modifiers_highlighting = hint
 resharper_arrange_type_modifiers_highlighting = hint
 resharper_built_in_type_reference_style_for_member_access_highlighting = hint

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ SamplePlugin assumes all the following prerequisites are met:
 * XIVLauncher, FINAL FANTASY XIV, and Dalamud have all been installed and the game has been run with Dalamud at least once.
 * XIVLauncher is installed to its default directories and configurations.
   * If a custom path is required for Dalamud's dev directory, it must be set with the `DALAMUD_HOME` environment variable.
-* A .NET Core 7 SDK has been installed and configured, or is otherwise available. (In most cases, the IDE will take care of this.)
+* A .NET Core 8 SDK has been installed and configured, or is otherwise available. (In most cases, the IDE will take care of this.)
 
 ### Building
 

--- a/SamplePlugin/Configuration.cs
+++ b/SamplePlugin/Configuration.cs
@@ -2,27 +2,27 @@
 using Dalamud.Plugin;
 using System;
 
-namespace SamplePlugin
+namespace SamplePlugin;
+
+[Serializable]
+public class Configuration : IPluginConfiguration
 {
-    [Serializable]
-    public class Configuration : IPluginConfiguration
+    public int Version { get; set; } = 0;
+
+    public bool IsConfigWindowMovable { get; set; } = true;
+    public bool SomePropertyToBeSavedAndWithADefault { get; set; } = true;
+
+    // the below exist just to make saving less cumbersome
+    [NonSerialized]
+    private DalamudPluginInterface? PluginInterface;
+
+    public void Initialize(DalamudPluginInterface pluginInterface)
     {
-        public int Version { get; set; } = 0;
+        PluginInterface = pluginInterface;
+    }
 
-        public bool SomePropertyToBeSavedAndWithADefault { get; set; } = true;
-
-        // the below exist just to make saving less cumbersome
-        [NonSerialized]
-        private DalamudPluginInterface? PluginInterface;
-
-        public void Initialize(DalamudPluginInterface pluginInterface)
-        {
-            this.PluginInterface = pluginInterface;
-        }
-
-        public void Save()
-        {
-            this.PluginInterface!.SavePluginConfig(this);
-        }
+    public void Save()
+    {
+        PluginInterface!.SavePluginConfig(this);
     }
 }

--- a/SamplePlugin/SamplePlugin.csproj
+++ b/SamplePlugin/SamplePlugin.csproj
@@ -3,11 +3,8 @@
   <Import Project="Dalamud.Plugin.Bootstrap.targets"/>
 
   <PropertyGroup>
-    <Authors></Authors>
-    <Company></Company>
     <Version>0.0.0.1</Version>
     <Description>A sample plugin.</Description>
-    <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
     <IsPackable>false</IsPackable>

--- a/SamplePlugin/Windows/ConfigWindow.cs
+++ b/SamplePlugin/Windows/ConfigWindow.cs
@@ -9,28 +9,51 @@ public class ConfigWindow : Window, IDisposable
 {
     private Configuration Configuration;
 
-    public ConfigWindow(Plugin plugin) : base(
-        "A Wonderful Configuration Window",
-        ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar |
-        ImGuiWindowFlags.NoScrollWithMouse)
+    // We give this window a constant ID using ###
+    // This allows for labels being dynamic, like "{FPS Counter}fps###XYZ counter window",
+    // and the window ID will always be "###XYZ counter window" for ImGui
+    public ConfigWindow(Plugin plugin) : base("A Wonderful Configuration Window###With a constant ID")
     {
-        this.Size = new Vector2(232, 75);
-        this.SizeCondition = ImGuiCond.Always;
+        Flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar |
+                ImGuiWindowFlags.NoScrollWithMouse;
 
-        this.Configuration = plugin.Configuration;
+        Size = new Vector2(232, 75);
+        SizeCondition = ImGuiCond.Always;
+
+        Configuration = plugin.Configuration;
     }
 
     public void Dispose() { }
 
+    public override void PreDraw()
+    {
+        // Flags must be added or removed before Draw() is being called, or they won't apply
+        if (Configuration.IsConfigWindowMovable)
+        {
+            Flags &= ~ImGuiWindowFlags.NoMove;
+        }
+        else
+        {
+            Flags |= ImGuiWindowFlags.NoMove;
+        }
+    }
+
     public override void Draw()
     {
         // can't ref a property, so use a local copy
-        var configValue = this.Configuration.SomePropertyToBeSavedAndWithADefault;
+        var configValue = Configuration.SomePropertyToBeSavedAndWithADefault;
         if (ImGui.Checkbox("Random Config Bool", ref configValue))
         {
-            this.Configuration.SomePropertyToBeSavedAndWithADefault = configValue;
+            Configuration.SomePropertyToBeSavedAndWithADefault = configValue;
             // can save immediately on change, if you don't want to provide a "Save and Close" button
-            this.Configuration.Save();
+            Configuration.Save();
+        }
+
+        var movable = Configuration.IsConfigWindowMovable;
+        if (ImGui.Checkbox("Movable Config Window", ref movable))
+        {
+            Configuration.IsConfigWindowMovable = movable;
+            Configuration.Save();
         }
     }
 }

--- a/SamplePlugin/Windows/MainWindow.cs
+++ b/SamplePlugin/Windows/MainWindow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using Dalamud.Interface.Internal;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
 
@@ -8,41 +9,48 @@ namespace SamplePlugin.Windows;
 
 public class MainWindow : Window, IDisposable
 {
-    private IDalamudTextureWrap GoatImage;
+    private IDalamudTextureWrap? GoatImage;
     private Plugin Plugin;
 
-    public MainWindow(Plugin plugin, IDalamudTextureWrap goatImage) : base(
-        "My Amazing Window", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
+    // We give this window a hidden ID using ##
+    // So that the user will see "My Amazing Window" as window title,
+    // but for ImGui the ID is "My Amazing Window##With a hidden ID"
+    public MainWindow(Plugin plugin, IDalamudTextureWrap? goatImage)
+        : base("My Amazing Window##With a hidden ID", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
     {
-        this.SizeConstraints = new WindowSizeConstraints
+        SizeConstraints = new WindowSizeConstraints
         {
             MinimumSize = new Vector2(375, 330),
             MaximumSize = new Vector2(float.MaxValue, float.MaxValue)
         };
 
-        this.GoatImage = goatImage;
-        this.Plugin = plugin;
+        GoatImage = goatImage;
+        Plugin = plugin;
     }
 
-    public void Dispose()
-    {
-        this.GoatImage.Dispose();
-    }
+    public void Dispose() { }
 
     public override void Draw()
     {
-        ImGui.Text($"The random config bool is {this.Plugin.Configuration.SomePropertyToBeSavedAndWithADefault}");
+        ImGui.Text($"The random config bool is {Plugin.Configuration.SomePropertyToBeSavedAndWithADefault}");
 
         if (ImGui.Button("Show Settings"))
         {
-            this.Plugin.DrawConfigUI();
+            Plugin.ToggleConfigUI();
         }
 
         ImGui.Spacing();
 
         ImGui.Text("Have a goat:");
-        ImGui.Indent(55);
-        ImGui.Image(this.GoatImage.ImGuiHandle, new Vector2(this.GoatImage.Width, this.GoatImage.Height));
-        ImGui.Unindent(55);
+        if (GoatImage != null)
+        {
+            ImGuiHelpers.ScaledIndent(55f);
+            ImGui.Image(GoatImage.ImGuiHandle, new Vector2(GoatImage.Width, GoatImage.Height));
+            ImGuiHelpers.ScaledIndent(-55f);
+        }
+        else
+        {
+            ImGui.Text("Image not found.");
+        }
     }
 }

--- a/SamplePlugin/packages.lock.json
+++ b/SamplePlugin/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0-windows7.0": {
+    "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.12, )",


### PR DESCRIPTION
### Removed
- Remove the mixture of this. and not using this. by setting editorconfig to always hint when this. is unnecessary 
- Remove unused `Name` property
- Remove empty properties from the csproj

### Cleanup
- Changed the requirement from NET 7 to 8
- Always use namespace without scoping
- Use ITextureProvider for the image instead of UIBuilder
- Use `Toggle()` for all windows
- Use `UiBuilder.OpenMainUi`

### Additions
- Add more examples for ImGui related behaviours
  - Comments that explain ## and ### in labels
  - Window flags adjustment in `PreDraw()`
  - Show usage of `ImGuiHelpers` for scaled indents instead of normal ImGui