### PR TITLE
Add PluginLog example

### DIFF
--- a/SamplePlugin/Plugin.cs
+++ b/SamplePlugin/Plugin.cs
@@ -13,6 +13,7 @@ public sealed class Plugin : IDalamudPlugin
     [PluginService] internal static IDalamudPluginInterface PluginInterface { get; private set; } = null!;
     [PluginService] internal static ITextureProvider TextureProvider { get; private set; } = null!;
     [PluginService] internal static ICommandManager CommandManager { get; private set; } = null!;
+    [PluginService] internal static IPluginLog Log { get; private set; } = null!;
 
     private const string CommandName = "/pmycommand";
 
@@ -48,6 +49,11 @@ public sealed class Plugin : IDalamudPlugin
 
         // Adds another button that is doing the same but for the main ui of the plugin
         PluginInterface.UiBuilder.OpenMainUi += ToggleMainUI;
+
+        // Add a simple message to the log with level set to information
+        // Use /xllog to open the log window in-game
+        // Example Output: 00:57:54.959 | INF | [SamplePlugin] ===A cool log message from Sample Plugin===
+        Log.Information($"===A cool log message from {PluginInterface.Manifest.Name}===");
     }
 
     public void Dispose()


### PR DESCRIPTION
Just a simple example on how to use the PluginLog as there was a number of users asking for this in the last months.
Also has a small example for accessing the manifest that is exposed to the plugin.