### PR TITLE
Add more examples and update Sdk to .02

### DIFF
--- a/SamplePlugin/SamplePlugin.csproj
+++ b/SamplePlugin/SamplePlugin.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/14.0.1">
+<Project Sdk="Dalamud.NET.Sdk/14.0.2">
   <PropertyGroup>
     <Version>0.0.0.1</Version>
     <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>

--- a/SamplePlugin/Windows/MainWindow.cs
+++ b/SamplePlugin/Windows/MainWindow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Textures;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
@@ -81,16 +82,35 @@ public class MainWindow : Window, IDisposable
                     ImGui.Text("Our current job is currently not valid.");
                     return;
                 }
-
+                
+                ImGui.AlignTextToFramePadding();
+                ImGui.Text($"Current job:");
+                
+                // Scaling hardcoded pixel values is important, as otherwise users with HUD scales above or below 100%
+                // won't be able to see everything.
+                ImGui.SameLine(120 * ImGuiHelpers.GlobalScale);
+                
+                // Get the icon id from a known offset + the class jobs id
+                var jobIconId = 62100 + playerState.ClassJob.RowId;
+                var iconTexture = Plugin.TextureProvider.GetFromGameIcon(new GameIconLookup(jobIconId)).GetWrapOrEmpty();
+                ImGui.Image(iconTexture.Handle, new Vector2(28, 28) * ImGuiHelpers.GlobalScale);
+                
+                ImGui.SameLine();
+                
                 // If you want to see the Macro representation of this SeString use `.ToMacroString()`
                 // More info about SeStrings: https://dalamud.dev/plugin-development/sestring/
-                ImGui.Text($"Our current job is ({playerState.ClassJob.RowId}) '{playerState.ClassJob.Value.Abbreviation}' with level {playerState.Level}");
-
+                ImGui.Text(playerState.ClassJob.Value.Abbreviation.ToString());
+                
+                ImGui.SameLine();
+                ImGui.Text($" [Level {playerState.Level}]");
+                
                 // Example for querying Lumina, getting the name of our current area.
                 var territoryId = Plugin.ClientState.TerritoryType;
                 if (Plugin.DataManager.GetExcelSheet<TerritoryType>().TryGetRow(territoryId, out var territoryRow))
                 {
-                    ImGui.Text($"We are currently in ({territoryId}) '{territoryRow.PlaceName.Value.Name}'");
+                    ImGui.Text($"Current location:");
+                    ImGui.SameLine(120 * ImGuiHelpers.GlobalScale);
+                    ImGui.Text(territoryRow.PlaceName.Value.Name.ToString());
                 }
                 else
                 {

--- a/SamplePlugin/packages.lock.json
+++ b/SamplePlugin/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[14.0.1, )",
-        "resolved": "14.0.1",
-        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
+        "requested": "[14.0.2, )",
+        "resolved": "14.0.2",
+        "contentHash": "dQJeq+8eyHzra4Cg5eZ/3LAeS3/UpvvLriYJGSncMK9LqJ7Q4B6jwcOsxo3PfxVd15xj+IzVFxkPqIBmPQu8/w=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",


### PR DESCRIPTION
Adds a new example on how to use `GlobalScale` while also showcasing `FromGameIcon`
Sdk has been updated to .02

<img width="438" height="490" alt="image" src="https://github.com/user-attachments/assets/5ad1a215-1a3e-4e3d-8a2f-dbfa055251db" />
